### PR TITLE
Avoid errors when using activity with groups/organizations

### DIFF
--- a/ckanext/pages/theme/templates_group/group/read_base.html
+++ b/ckanext/pages/theme/templates_group/group/read_base.html
@@ -3,8 +3,8 @@
 {% block content_primary_nav %}
   {{ super() }}
   {% if h.ckan_version().split('.')[1] | int >= 9 %}
-    {{ h.build_nav_icon('pages.group_pages_index', _('Pages'), id=c.group_dict.name, icon='file') }}
+    {{ h.build_nav_icon('pages.group_pages_index', _('Pages'), id=group_dict.name, icon='file') }}
   {% else %}
-    {{ h.build_nav_icon('group_pages_index', _('Pages'), id=c.group_dict.name, icon='file') }}
+    {{ h.build_nav_icon('group_pages_index', _('Pages'), id=group_dict.name, icon='file') }}
   {% endif %}
 {% endblock %}

--- a/ckanext/pages/theme/templates_organization/organization/read_base.html
+++ b/ckanext/pages/theme/templates_organization/organization/read_base.html
@@ -3,8 +3,8 @@
 {% block content_primary_nav %}
   {{ super() }}
   {% if h.ckan_version().split('.')[1] | int >= 9 %}
-    {{ h.build_nav_icon('pages.organization_pages_index', _('Pages'), id=c.group_dict.name, icon='file') }}
+    {{ h.build_nav_icon('pages.organization_pages_index', _('Pages'), id=group_dict.name, icon='file') }}
   {% else %}
-    {{ h.build_nav_icon('organization_pages_index', _('Pages'), id=c.group_dict.name, icon='file') }}
+    {{ h.build_nav_icon('organization_pages_index', _('Pages'), id=group_dict.name, icon='file') }}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
[Avoid error](https://github.com/ckan/ckanext-pages/commit/505a2d0b3992bcfdf0328cc0a5a24050c94c9e42) 

```log
...
File "/srv/app/src_extensions/ckanext-harvest/ckanext/harvest/templates/base.html", line 1, in top-level template code
{% ckan_extends %}
File "/srv/app/src/ckan/ckan/templates/base.html", line 108, in top-level template code
{%- block page %}{% endblock -%}
File "/srv/app/src/ckan/ckan/templates/page.html", line 19, in block 'page'
{%- block content %}
File "/srv/app/src/ckan/ckan/templates/page.html", line 22, in block 'content'
{% block main_content %}
File "/srv/app/src/ckan/ckan/templates/page.html", line 74, in block 'main_content'
{% block primary %}
File "/srv/app/src/ckan/ckan/templates/page.html", line 87, in block 'primary'
{% block primary_content %}
File "/srv/app/src/ckan/ckan/templates/page.html", line 89, in block 'primary_content'
{% block page_header %}
File "/srv/app/src/ckan/ckan/templates/page.html", line 97, in block 'page_header'
{% block content_primary_nav %}{% endblock %}
File "/srv/app/src/ckan/ckanext/activity/templates/organization/read_base.html", line 4, in block 'content_primary_nav'
{{ super() }}
File "/srv/app/src_extensions/ckanext-pages/ckanext/pages/theme/templates_organization/organization/read_base.html", line 6, in block 'content_primary_nav'
{{ h.build_nav_icon('pages.organization_pages_index', _('Pages'), id=c.group_dict.name, icon='file') }}
File "/usr/local/lib/python3.10/site-packages/jinja2/environment.py", line 487, in getattr
return getattr(obj, attribute)
jinja2.exceptions.UndefinedError: 'werkzeug.local.LocalProxy object' has no attribute 'group_dict'
```